### PR TITLE
Use taglib location for tld files

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -288,5 +288,24 @@ https://confluence.slac.stanford.edu/display/LSSTCAM/eTraveler+frontend+document
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     <!-- Done adding Sitemesh Filter -->
+    
+    <jsp-config>
+      <taglib>
+        <taglib-uri>/tlds/dcTagLibrary.tld</taglib-uri>
+        <taglib-location>/tlds/dcTagLibrary.tld</taglib-location>
+      </taglib>
+      <taglib>
+        <taglib-uri>/tlds/eclTagLibrary.tld</taglib-uri>
+        <taglib-location>/tlds/eclTagLibrary.tld</taglib-location>
+      </taglib>
+      <taglib>
+        <taglib-uri>/tlds/resultsLibrary.tld</taglib-uri>
+        <taglib-location>/tlds/resultsLibrary.tld</taglib-location>
+      </taglib>
+      <taglib>
+        <taglib-uri>/tlds/uploads.tld</taglib-uri>
+        <taglib-location>/tlds/uploads.tld</taglib-location>
+      </taglib>
+    </jsp-config>
 
 </web-app>


### PR DESCRIPTION
The taglib uri is an absolute location, and that location is not under WEB-INF or anything. 

This makes tomcat 8.5 unhappy. We add taglib-location so it can find it. If we had used a proper url instead, it should have happily found it.